### PR TITLE
Revert "Make action runs async"

### DIFF
--- a/modules/podman.js
+++ b/modules/podman.js
@@ -178,14 +178,18 @@ class Version {
 function runCommand(command, containerName) {
     const cmdline = `podman ${command} ${containerName}`;
     Logger.info(`running command ${cmdline}`);
-    const ok = GLib.spawn_command_line_async(cmdline);
-    if (ok) {
+    // eslint-disable-next-line no-unused-vars
+    const [_res, out, err, status] = GLib.spawn_command_line_sync(cmdline);
+    if (status === 0) {
         Logger.info(`command on ${containerName} terminated successfully`);
     } else {
         const errMsg = `Error occurred when running ${command} on container ${containerName}`;
         Main.notify(errMsg);
         Logger.info(errMsg);
+        Logger.info(err);
     }
+    Logger.debug(out);
+    return out;
 }
 
 /** runCommandInTerminal runs a podman container command using the cli


### PR DESCRIPTION
This reverts commit 467fbed288c9a54e7d086ac9bb23ffa784891f2b.

Running in async means loosing the output, so commands like inspect
are failing silently. Reverting till I'll figure out a way to get the
output. Maybe async/await with while using a synced cli invocation?