### PR TITLE
Stop spawning podman synchronously

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -24,7 +24,6 @@ function enable() {
     Podman.discoverPodmanVersion();
     containersMenu = new ContainersMenu();
     Logger.debug(containersMenu);
-    containersMenu.renderMenu();
     Main.panel.addToStatusArea("containers-menu", containersMenu);
 }
 
@@ -58,15 +57,17 @@ var ContainersMenu = GObject.registerClass(
 
             hbox.add_child(icon);
             this.add_child(hbox);
-            this.connect("button_press_event", () => {
+
+            this.menu.connect("open-state-changed", () => {
                 if (this.menu.isOpen) {
                     this.menu.removeAll();
-                    this.renderMenu();
+                    this._renderMenu();
                 }
             });
+            this._renderMenu();
         }
 
-        renderMenu() {
+        _renderMenu() {
             try {
                 const containers = Podman.getContainers();
                 Logger.info(`found ${containers.length} containers`);

--- a/extension.js
+++ b/extension.js
@@ -60,7 +60,6 @@ var ContainersMenu = GObject.registerClass(
 
             this.menu.connect("open-state-changed", () => {
                 if (this.menu.isOpen) {
-                    this.menu.removeAll();
                     this._renderMenu();
                 }
             });
@@ -71,6 +70,8 @@ var ContainersMenu = GObject.registerClass(
             try {
                 const containers = Podman.getContainers();
                 Logger.info(`found ${containers.length} containers`);
+
+                this.menu.removeAll();
                 if (containers.length > 0) {
                     containers.forEach(container => {
                         Logger.debug(container.toString());
@@ -81,6 +82,7 @@ var ContainersMenu = GObject.registerClass(
                     this.menu.addMenuItem(new PopupMenu.PopupMenuItem("No containers detected"));
                 }
             } catch (err) {
+                this.menu.removeAll();
                 const errMsg = "Error occurred when fetching containers";
                 this.menu.addMenuItem(new PopupMenu.PopupMenuItem(errMsg));
                 Logger.info(`${errMsg}: ${err}`);

--- a/extension.js
+++ b/extension.js
@@ -65,9 +65,9 @@ var ContainersMenu = GObject.registerClass(
             this._renderMenu();
         }
 
-        _renderMenu() {
+        async _renderMenu() {
             try {
-                const containers = Podman.getContainers();
+                const containers = await Podman.getContainers();
                 Logger.info(`found ${containers.length} containers`);
 
                 this.menu.removeAll();
@@ -137,9 +137,9 @@ var ContainerSubMenuMenuItem = GObject.registerClass(
             this.inspected = false;
 
             // add more stats and info - inspect - SLOW
-            this.connect("button_press_event", () => {
+            this.connect("button-press-event", async () => {
                 if (!this.inspected) {
-                    container.inspect();
+                    await container.inspect();
                     this.inspected = true;
                     ipAddrMenuItem.label.set_text(`${ipAddrMenuItem.label.text} ${container.ipAddress}`);
                 }

--- a/extension.js
+++ b/extension.js
@@ -84,7 +84,6 @@ var ContainersMenu = GObject.registerClass(
                 this.menu.addMenuItem(new PopupMenu.PopupMenuItem(errMsg));
                 Logger.info(`${errMsg}: ${err}`);
             }
-            this.show();
         }
     });
 

--- a/extension.js
+++ b/extension.js
@@ -21,7 +21,6 @@ let containersMenu;
 // eslint-disable-next-line no-unused-vars
 function enable() {
     Logger.info("enabling containers extension");
-    Podman.discoverPodmanVersion();
     containersMenu = new ContainersMenu();
     Logger.debug(containersMenu);
     Main.panel.addToStatusArea("containers-menu", containersMenu);

--- a/modules/podman.js
+++ b/modules/podman.js
@@ -12,6 +12,10 @@ let podmanVersion;
 /** @returns list of containers : Container[] */
 // eslint-disable-next-line no-unused-vars
 function getContainers() {
+    if (podmanVersion === undefined) {
+        discoverPodmanVersion();
+    }
+
     const [res, out, err, status] = GLib.spawn_command_line_sync("podman ps -a --format json");
 
     if (!res) {

--- a/modules/podman.js
+++ b/modules/podman.js
@@ -203,10 +203,10 @@ function runCommand(command, containerName) {
 function runCommandInTerminal(command, containerName, args) {
     const cmdline = `gnome-terminal -- ${command} ${containerName} ${args}`;
     Logger.info(`running command ${cmdline}`);
-    const ok = GLib.spawn_command_line_async(cmdline);
-    if (ok) {
+    try {
+        GLib.spawn_command_line_async(cmdline);
         Logger.info(`command on ${containerName} terminated successfully`);
-    } else {
+    } catch (e) {
         const errMsg = `Error occurred when running ${command} on container ${containerName}`;
         Main.notify(errMsg);
         Logger.info(errMsg);


### PR DESCRIPTION
See patches:
﻿- containersMenu: Remove superfluous show() call
- containersMenu: Handle refreshing menu internally
- containersMenu: Remove old items when refreshing menu
- podman: Fix runCommandInTerminal() error handling
- podman: Ensure podmanVersion internally
- podman: Always spawn podman asynchronously
