### PR TITLE
Apply button:checked style for decendents only

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -18,7 +18,7 @@
 	color: SkyBlue;
 }
 
-.button:checked {
+.containers-extension-menu .button:checked {
     color: #eeeeec;
     background-color: #2d2d2d;
     border-color: #191919;


### PR DESCRIPTION
Set the style of button:checkd to decendents of classname of this
whole extension menu. Otherwise this affects other buttons, such as the
the quick settings panel.

Fixes: #42

Signed-off-by: Roy Golan <rgolan@redhat.com>
