### PR TITLE
Update podman.js to sort containers by name

### DIFF
--- a/src/modules/podman.js
+++ b/src/modules/podman.js
@@ -25,7 +25,7 @@ export async function getContainers(settings) {
     let jsonContainers;
 
     try {
-        const out = await spawnCommandline("podman ps -a --format json");
+        const out = await spawnCommandline("podman ps -a --sort names --format json");
         jsonContainers = JSON.parse(out);
     } catch (e) {
         console.error(e.message);


### PR DESCRIPTION
The list of podman containers shown in the gnome shell menu is currently unsorted, which can be slightly confusing when you have several containers that have similar names. This pull request changes the default behaviour to sort the list of containers by name.