### PR TITLE
Add support for Gnome 49

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,7 +7,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "settings-schema": "org.gnome.shell.extensions.containers"
 }


### PR DESCRIPTION
Description

Add support for GNOME 49. Tested with make install and the extension loads-works correctly.

Changes:
- Updated metadata.json with GNOME 49 support.
- Verified functionality on GNOME 49 (see screenshot).

<img width="683" height="738" alt="image" src="https://github.com/user-attachments/assets/7be0a375-c7f9-4e55-9526-e280ba2ba382" />
